### PR TITLE
new option g:EchoFuncBallonOnly and g:EchoFuncTrimSize 

### DIFF
--- a/after/plugin/echofunc.vim
+++ b/after/plugin/echofunc.vim
@@ -6,7 +6,7 @@
 "               supports.
 " Authors:      Ming Bai <mbbill AT gmail DOT com>,
 "               Wu Yongwei <wuyongwei AT gmail DOT com>
-" Last Change:  2014-02-17 20:16:11
+" Last Change:  2016-10-08 19:13:42
 " Version:      2.0
 "
 " Install:      1. Put echofunc.vim to /plugin directory.
@@ -85,6 +85,19 @@
 "                 To add more mappings in g:EchoFuncPathMapping, search
 "                 this script and you will know how to do it.
 "
+"               g:EchoFuncBallonOnly
+"                 Set to non-zero to show function only in ballons (no echo
+"                 in cmdline/statusline), default is 0.
+"                 Sometimes when running vim in a small window, functions
+"                 with long names will occupy to many lines in statusline, 
+"                 which will destroy the origin layout of windows.
+"                 This option allows you to use echofunc in a neat way in 
+"                 small windows.
+"
+"               g:EchoFuncTrimSize
+"                 Trim text length to fit window size, default is 0,
+"                 cmdheight may not be changed if enable.
+"
 "
 " Thanks:       edyfox
 "               minux
@@ -116,6 +129,14 @@ endif
 
 if !exists("g:EchoFuncPathMappingEnabled")
     let g:EchoFuncPathMappingEnabled = 1
+endif
+
+if !exists("g:EchoFuncBallonOnly")
+    let g:EchoFuncBallonOnly = 0
+endif
+
+if !exists("g:EchoFuncTrimSize")
+    let g:EchoFuncTrimSize = 0
 endif
 
 func! g:EchoFuncTruncatePath(path, style)
@@ -213,6 +234,14 @@ function! s:EchoFuncDisplay()
     let statusline=(&laststatus==1 && winnr('$')>1) || (&laststatus==2)
     let reqspaces_lastline=(statusline || !&ruler) ? 12 : 29
     let width=len(content)
+    let limit=wincols-reqspaces_lastline
+    if g:EchoFuncTrimSize != 0 
+        let allowedheight=&cmdheight
+        if width + 1 >= limit
+            let content=strpart(content, 0, limit - 4)
+            let width=len(content)
+        endif
+    endif
     let height=width/wincols+1
     let cols_lastline=width%wincols
     if cols_lastline > wincols-reqspaces_lastline
@@ -681,7 +710,7 @@ function! s:CheckTagsLanguage(filetype)
 endfunction
 
 function! CheckedEchoFuncStart()
-    if s:CheckTagsLanguage(&filetype)
+    if s:CheckTagsLanguage(&filetype) && g:EchoFuncBallonOnly == 0
         call EchoFuncStart()
     endif
 endfunction


### PR DESCRIPTION
new option `g:EchoFuncBallonOnly` and `g:EchoFuncTrimSize` to offer a neat way to running echofunc when vim is running in small window.

### g:EchoFuncBallonOnly

Sometimes when running vim in a small window, functions with long names will occupy to many lines in statusline, which will destroy the origin layout of windows. This option allows you to use echofunc in a neat way in small windows.

### g:EchoFuncTrimSize

Trim text length to fit window size, default is 0, cmdheight may not be changed if set to non-zero.

